### PR TITLE
Fix obligatory input for area of issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,15 +11,17 @@ body:
       options:
         - label: I have searched the existing issues
           required: true
-  - type: checkboxes
+  - type: dropdown
+    id: area
     attributes:
       label: What type of issue are you facing
       description: What type of issue are you facing?
       options:
-        - label: bug report
-        - label: documentation issue or request
-        - label: regression (a behavior that used to work and stopped in a new version)
-          required: true
+        - bug report
+        - documentation issue or request
+        - regression (a behavior that used to work and stopped in a new version)
+    validations:
+      required: true
   - type: textarea
     attributes:
       label: Describe the bug

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -4,18 +4,20 @@ title: "[FEATURE]"
 labels: [enhancement]
 assignees: [MartinPankraz]
 body:
-  - type: checkboxes
+  - type: dropdown
     attributes:
       label: What area do you want to see improved?
       description: Specify the main area that you want to see improved.
       options:
-        - label: app code
-        - label: documentation
-        - label: infrastructure setup
-        - label: developer experience (GitHub CodeSpaces etc.)
-        - label: other
-          required: true
+        - app code
+        - documentation
+        - infrastructure setup
+        - developer experience (GitHub CodeSpaces etc.)
+        - other
+    validations:
+      required: true
   - type: textarea
+    id: area
     attributes:
       label: Is your feature request related to a problem? Please describe.
       description: Provide a clear and concise description of what the problem is e.g., I'm always frustrated when [...]


### PR DESCRIPTION
## Purpose

* This PR fixes the obligatory input issue mentioned in #35 
* It switches the type of input field to drop down to enable the validation on the complete section and not on a single value

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Test the code
```
- Open a issue (bug or feature request)
```

## What to Check

Verify that the following are valid:

*  You should be forced to select one area of impact of the bug/feature request

## Other Information

This means that only a single input is possible. Description states that main impacted area should be specified, so this should be fine.
