### PR TITLE
Feat/bicep health endpoint

### DIFF
--- a/infra/app/api.bicep
+++ b/infra/app/api.bicep
@@ -10,6 +10,10 @@ param appSettings object = {}
 param keyVaultName string
 param serviceName string = 'sap-cloud-sdk-api'
 param healthCheckPath string = '/health'
+//Set this parameter to true im main.bicep if you want to use the free plan that does not support 64 bit workers
+param use32BitWorkerProcess bool = false
+
+param alwaysOn bool = true
 
 module api '../core_local/host/appservice.bicep' = {
   name: '${name}-app-module'
@@ -27,6 +31,8 @@ module api '../core_local/host/appservice.bicep' = {
     runtimeVersion: '16'
     scmDoBuildDuringDeployment: true
     healthCheckPath: healthCheckPath
+    use32BitWorkerProcess: use32BitWorkerProcess
+    alwaysOn: alwaysOn
   }
 }
 

--- a/infra/app/api.bicep
+++ b/infra/app/api.bicep
@@ -10,7 +10,6 @@ param appSettings object = {}
 param keyVaultName string
 param serviceName string = 'sap-cloud-sdk-api'
 param healthCheckPath string = '/health'
-//Set this parameter to true im main.bicep if you want to use the free plan that does not support 64 bit workers
 param use32BitWorkerProcess bool = false
 
 param alwaysOn bool = true

--- a/infra/app/api.bicep
+++ b/infra/app/api.bicep
@@ -9,8 +9,9 @@ param appServicePlanId string
 param appSettings object = {}
 param keyVaultName string
 param serviceName string = 'sap-cloud-sdk-api'
+param healthCheckPath string = '/health'
 
-module api '../core/host/appservice.bicep' = {
+module api '../core_local/host/appservice.bicep' = {
   name: '${name}-app-module'
   params: {
     name: name
@@ -25,6 +26,7 @@ module api '../core/host/appservice.bicep' = {
     runtimeName: 'node'
     runtimeVersion: '16'
     scmDoBuildDuringDeployment: true
+    healthCheckPath: healthCheckPath
   }
 }
 

--- a/infra/core_local/host/appservice.bicep
+++ b/infra/core_local/host/appservice.bicep
@@ -1,0 +1,101 @@
+param name string
+param location string = resourceGroup().location
+param tags object = {}
+
+// Reference Properties
+param applicationInsightsName string = ''
+param appServicePlanId string
+param keyVaultName string = ''
+param managedIdentity bool = !empty(keyVaultName)
+
+// Runtime Properties
+@allowed([
+  'dotnet', 'dotnetcore', 'dotnet-isolated', 'node', 'python', 'java', 'powershell', 'custom'
+])
+param runtimeName string
+param runtimeNameAndVersion string = '${runtimeName}|${runtimeVersion}'
+param runtimeVersion string
+
+// Microsoft.Web/sites Properties
+param kind string = 'app,linux'
+
+// Microsoft.Web/sites/config
+param allowedOrigins array = []
+param alwaysOn bool = true
+param appCommandLine string = ''
+param appSettings object = {}
+param clientAffinityEnabled bool = false
+param enableOryxBuild bool = contains(kind, 'linux')
+param functionAppScaleLimit int = -1
+param linuxFxVersion string = runtimeNameAndVersion
+param minimumElasticInstanceCount int = -1
+param numberOfWorkers int = -1
+param scmDoBuildDuringDeployment bool = false
+param use32BitWorkerProcess bool = false
+
+// Additional parameters for app service - not part of azd core
+param healthCheckPath string = ''
+
+resource appService 'Microsoft.Web/sites@2022-03-01' = {
+  name: name
+  location: location
+  tags: tags
+  kind: kind
+  properties: {
+    serverFarmId: appServicePlanId
+    siteConfig: {
+      linuxFxVersion: linuxFxVersion
+      alwaysOn: alwaysOn
+      ftpsState: 'FtpsOnly'
+      appCommandLine: appCommandLine
+      numberOfWorkers: numberOfWorkers != -1 ? numberOfWorkers : null
+      minimumElasticInstanceCount: minimumElasticInstanceCount != -1 ? minimumElasticInstanceCount : null
+      use32BitWorkerProcess: use32BitWorkerProcess
+      functionAppScaleLimit: functionAppScaleLimit != -1 ? functionAppScaleLimit : null
+      cors: {
+        allowedOrigins: union([ 'https://portal.azure.com', 'https://ms.portal.azure.com' ], allowedOrigins)
+      }
+      healthCheckPath: healthCheckPath
+    }
+    clientAffinityEnabled: clientAffinityEnabled
+    httpsOnly: true
+  }
+
+  identity: { type: managedIdentity ? 'SystemAssigned' : 'None' }
+
+  resource configAppSettings 'config' = {
+    name: 'appsettings'
+    properties: union(appSettings,
+      {
+        SCM_DO_BUILD_DURING_DEPLOYMENT: string(scmDoBuildDuringDeployment)
+        ENABLE_ORYX_BUILD: string(enableOryxBuild)
+      },
+      !empty(applicationInsightsName) ? { APPLICATIONINSIGHTS_CONNECTION_STRING: applicationInsights.properties.ConnectionString } : {},
+      !empty(keyVaultName) ? { AZURE_KEY_VAULT_ENDPOINT: keyVault.properties.vaultUri } : {})
+  }
+
+  resource configLogs 'config' = {
+    name: 'logs'
+    properties: {
+      applicationLogs: { fileSystem: { level: 'Verbose' } }
+      detailedErrorMessages: { enabled: true }
+      failedRequestsTracing: { enabled: true }
+      httpLogs: { fileSystem: { enabled: true, retentionInDays: 1, retentionInMb: 35 } }
+    }
+    dependsOn: [
+      configAppSettings
+    ]
+  }
+}
+
+resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' existing = if (!(empty(keyVaultName))) {
+  name: keyVaultName
+}
+
+resource applicationInsights 'Microsoft.Insights/components@2020-02-02' existing = if (!empty(applicationInsightsName)) {
+  name: applicationInsightsName
+}
+
+output identityPrincipalId string = managedIdentity ? appService.identity.principalId : ''
+output name string = appService.name
+output uri string = 'https://${appService.properties.defaultHostName}'


### PR DESCRIPTION
## Purpose

* Adjustments to set health endpoint
*  Fixes for deployment in free plan (`alwaysOn` and `worker32bit` settings)
* Closes issue #34 for bicep based IaC

## Does this introduce a breaking change?

```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Test the code

```
Variant A: Execute `azd provision` or `azd up` as is
Varaiant B: Change the `skuName` in `main.bicep` to `B1`
```

## What to Check
Verify that the following are valid

* The deployment must be successfully executed
* The deployment is successfully executed, the health endpoint is set  

## Other Information

In the default plan for our setup (`F1`) the health endpoint cannot be enabled

The PR also contains several fixes for the setup of an app service with free plan concerning the limitations towards 32bit worker and alwaysOn setting. 
