### PR TITLE
Revert "chore: switching ot azd as a feature in devcontainers"

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,6 @@
+ARG IMAGE=bullseye
+FROM --platform=amd64 mcr.microsoft.com/devcontainers/${IMAGE}
+RUN export DEBIAN_FRONTEND=noninteractive \
+     && apt-get update && apt-get install -y xdg-utils \
+     && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+RUN curl -fsSL https://aka.ms/install-azd.sh | bash

--- a/.devcontainer/azd-bicep/Dockerfile
+++ b/.devcontainer/azd-bicep/Dockerfile
@@ -1,0 +1,6 @@
+ARG IMAGE=bullseye
+FROM --platform=amd64 mcr.microsoft.com/devcontainers/${IMAGE}
+RUN export DEBIAN_FRONTEND=noninteractive \
+     && apt-get update && apt-get install -y xdg-utils \
+     && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+RUN curl -fsSL https://aka.ms/install-azd.sh | bash

--- a/.devcontainer/azd-terraform/Dockerfile
+++ b/.devcontainer/azd-terraform/Dockerfile
@@ -1,0 +1,6 @@
+ARG IMAGE=bullseye
+FROM --platform=amd64 mcr.microsoft.com/devcontainers/${IMAGE}
+RUN export DEBIAN_FRONTEND=noninteractive \
+     && apt-get update && apt-get install -y xdg-utils \
+     && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+RUN curl -fsSL https://aka.ms/install-azd.sh | bash

--- a/.devcontainer/azd-terraform/devcontainer.json
+++ b/.devcontainer/azd-terraform/devcontainer.json
@@ -1,9 +1,13 @@
 // For format details, see https://aka.ms/devcontainer.json.
 {
 	"name": "Azure Developer CLI (Terraform)",
-	"image": "mcr.microsoft.com/devcontainers/typescript-node:18-bullseye",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": {
+			"IMAGE": "typescript-node:18"
+		}
+	},
 	"features": {
-		"ghcr.io/azure/azure-dev/azd:latest": {},
 		"ghcr.io/devcontainers-contrib/features/nestjs-cli:2": {},
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
 		"ghcr.io/devcontainers/features/azure-cli:1": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,4 +1,5 @@
 // For format details, see https://aka.ms/devcontainer.json.
+// Making Bicep flavor default container to cater for easier GitHub Codespace generation UI flow. Choose container config screen to switch to other containers.
 {
 	"name": "Azure Developer CLI (Bicep)",
 	"build": {


### PR DESCRIPTION
Reverts Azure-Samples/app-service-javascript-sap-cloud-sdk-quickstart#72

@lechnerc77 pre-builds failing without error message and custom re-build in Codespace does not fix. AZD command not available. Seems like the pipelining is broken somehow without error message.

Should we revert?