### PR TITLE
Update invalid slugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ languages:
 - powershell
 products:
 - azure
-- azure-application-insights
+- azure-monitor
 - azure-key-vault
 - azure-app-service
 - azure-api-management


### PR DESCRIPTION
According to [doc](https://review.learn.microsoft.com/en-us/help/platform/metadata-taxonomies?branch=main#product), update invalid product slug `azure-application-insights` to `azure-monitor`.

@hemarina, @MartinPankraz  for notification.